### PR TITLE
Clarify usage of 'workspace' in the docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -66,7 +66,7 @@
         <header>
           <h2>Install</h2>
           <p>
-            Run this command in your Yarn workspace <br />to install (or upgrade
+            Run this command in your Yarn project<br />to install (or upgrade
             to) the latest version.
           </p>
         </header>
@@ -298,11 +298,11 @@
         </p>
         <p>
           If you run <code>yarn build</code> from any other directory in your
-          yarn workspace, your whole workspace will be built.
+          yarn workspaces, your whole project will be built.
         </p>
         <p>
           Because of this, it's easy to integrate into your existing yarn
-          workspace. And to build packages in langauges other than Javascript.
+          workspaces. And to build packages in langauges other than Javascript.
         </p>
       </article>
       <hr />
@@ -310,7 +310,7 @@
         <h2>Build</h2>
         <p>
           Build a single package (and its dependencies) or all packages in your
-          workspace.
+          project.
         </p>
         <p>Run <code>yarn build</code></p>
         <asciinema-player


### PR DESCRIPTION
What a great project! I love the minimalistic design and the tight integration with Yarn workspaces.

On the homepage, I noticed some slightly confusing usage of _package_ vs. _workspace_ (singular) – they both mean the same thing in the Yarn lingo so I found some of the sentences slightly confusing. I've switched to a plural or the term _project_ (which Yarn uses for the overall thing, a "set of workspaces") – not sure if it's the best description but at least it's a concrete proposal vs. just opening an issue 😄.

Thanks for the project again!