### PR TITLE
feat: Warn if a workspace has no build script

### DIFF
--- a/packages/plugins/plugin-build/src/commands/build/index.ts
+++ b/packages/plugins/plugin-build/src/commands/build/index.ts
@@ -130,6 +130,7 @@ export default class Build extends BaseCommand {
           buildCommand: this.buildCommand,
           cli: runScript,
           dryRun: this.dryRun,
+          verbose: this.verbose
         });
 
         await supervisor.setup();

--- a/packages/plugins/plugin-build/src/commands/build/supervisor.ts
+++ b/packages/plugins/plugin-build/src/commands/build/supervisor.ts
@@ -99,6 +99,7 @@ class BuildSupervisor {
   buildMutexes: { [relativCwd: string]: Mutex } = {};
   currentBuildTarget?: string;
   dryRun = false;
+  verbose = false;
   queue: PQueue;
 
   entrypoints: Node[] = [];
@@ -131,6 +132,7 @@ class BuildSupervisor {
     cli,
     configuration,
     dryRun,
+    verbose,
   }: {
     project: Project;
     report: StreamReport;
@@ -138,6 +140,7 @@ class BuildSupervisor {
     cli: BuildCommandCli;
     configuration: Configuration;
     dryRun: boolean;
+    verbose: boolean;
   }) {
     this.configuration = configuration;
     this.project = project;
@@ -145,6 +148,7 @@ class BuildSupervisor {
     this.buildCommand = buildCommand;
     this.cli = cli;
     this.dryRun = dryRun;
+    this.verbose = verbose;
 
     this.queue = new PQueue({
       concurrency: this.concurrency, // TODO: make this customisable
@@ -797,6 +801,14 @@ class BuildSupervisor {
           );
 
           if (!command) {
+            if (this.verbose) {
+              this.buildReporter.emit(
+                BuildReporterEvents.info,
+                workspace.relativeCwd,
+                `Missing \`${this.buildCommand}\` script in manifest.`
+              );
+            }
+
             this.buildReporter.emit(
               BuildReporterEvents.success,
               workspace.relativeCwd


### PR DESCRIPTION
When running `yarn build --verbose`, it will now print an "error" if a workspace is missing the expected build command:

For example:
```shell
╰─ rm .yarn/local-build-cache.json && yarn build --verbose
➤ YN0000: ┌ Building All
➤ YN0009: │ ┌ Errors for packages/examples/phrases/in-hac
➤ YN0009: │ │ Missing `build` script in manifest.
➤ YN0009: │ └ End packages/examples/phrases/in-hac
➤ YN0009: │ ┌ Errors for packages/examples/words/sit
➤ YN0009: │ │ src/index.ts:1:14 - error TS1005: ';' expected.
➤ YN0009: │ │ 1 ftygukjhu +c asda
➤ YN0009: │ │                ~~~~
➤ YN0009: │ │ Found 1 error.
➤ YN0009: │ └ End packages/examples/words/sit
➤ YN0000: └ Build finished with 2 errors
➤ YN0000: [11:2/13]
➤ YN0000: Done in 12s 97ms
```