### PR TITLE
fix: Build failures produce 0 exit code

### DIFF
--- a/packages/plugins/plugin-build/src/commands/build/index.ts
+++ b/packages/plugins/plugin-build/src/commands/build/index.ts
@@ -2,6 +2,7 @@ import { BaseCommand } from "@yarnpkg/cli";
 import {
   Configuration,
   Manifest,
+  MessageName,
   Project,
   StreamReport,
   Workspace,
@@ -165,7 +166,10 @@ export default class Build extends BaseCommand {
         }
 
         // build all the things
-        await supervisor.run();
+        const ranWithoutErrors = await supervisor.run();
+        if (ranWithoutErrors === false) {
+          report.reportError(MessageName.BUILD_FAILED, "Build failed");
+        }
       }
     );
 

--- a/packages/plugins/plugin-build/src/commands/build/supervisor.ts
+++ b/packages/plugins/plugin-build/src/commands/build/supervisor.ts
@@ -603,6 +603,8 @@ class BuildSupervisor {
 
     // commit the build log
     await this.saveBuildLog();
+
+    return this.buildReport.failCount === 0;
   };
 
   // This is a very simple requestAnimationFrame polyfil


### PR DESCRIPTION
Build failures are now communicated back to the caller, which will in turn raise an error on the report to ensure a non-0 exit code.

Fixes #14