### PR TITLE
fix: Failed projects are not rebuilt

### DIFF
--- a/packages/plugins/plugin-build/src/commands/build/supervisor.ts
+++ b/packages/plugins/plugin-build/src/commands/build/supervisor.ts
@@ -221,6 +221,10 @@ class BuildSupervisor {
     };
 
     for (const [id, entry] of this.buildLog) {
+      if (entry.status !== BuildStatus.succeeded) {
+        continue;
+      }
+
       buildLogFile.packages[id] = {
         lastModified: entry.lastModified,
       };


### PR DESCRIPTION
Projects were persisted to the build log, regardless of their build result. Preventing failed builds to be written to the build log ensures they are rebuilt on the next attempt.

Fixes #15