### PR TITLE
fix: Build command ignored

### DIFF
--- a/packages/plugins/plugin-build/src/commands/build/index.ts
+++ b/packages/plugins/plugin-build/src/commands/build/index.ts
@@ -106,7 +106,7 @@ export default class Build extends BaseCommand {
 
           try {
             const exitCode =
-              (await this.cli.run(["run", "build"], {
+              (await this.cli.run(["run", command], {
                 cwd,
                 stdout,
                 stderr,


### PR DESCRIPTION
The `buildCommand` already is "build" by default and must be passed through to not have the user choice ignored.

Fixes #11