### PR TITLE
fix: Workspaces are built inconsistently

### DIFF
--- a/packages/plugins/plugin-build/src/commands/build/supervisor.ts
+++ b/packages/plugins/plugin-build/src/commands/build/supervisor.ts
@@ -386,6 +386,19 @@ class BuildSupervisor {
       );
       parent.addBuildCallback(this.build(workspace));
       return true;
+
+    } else {
+      // Use the previous log entry if we don't need to rebuild.
+      // This ensures we always have all our build targets in the log.
+      const previousBuildLog = this.buildLog?.get(workspace.relativeCwd);
+      if (previousBuildLog) {
+        this.buildLog?.set(workspace.relativeCwd, {
+          lastModified: previousBuildLog.lastModified,
+          status: BuildStatus.succeeded,
+          haveCheckedForRebuild: true,
+          rebuild: false,
+        });
+      }
     }
 
     return false;


### PR DESCRIPTION
If a workspace was not rebuilt, it would not be written to the state file. This caused the project to be rebuilt on the next build, as it appeared to have never been built. The projects that then didn't have to be rebuilt on this run, would be missing from the state file and so on.