### PR TITLE
fix: Incomplete configuration construction

### DIFF
--- a/packages/plugins/plugin-build/src/commands/build/index.ts
+++ b/packages/plugins/plugin-build/src/commands/build/index.ts
@@ -74,7 +74,7 @@ export default class Build extends BaseCommand {
       this.context.plugins
     );
 
-    const pluginConfiguration: YarnBuildConfiguration = await GetPluginConfiguration();
+    const pluginConfiguration: YarnBuildConfiguration = await GetPluginConfiguration(configuration);
 
     const report = await StreamReport.start(
       {

--- a/packages/plugins/plugin-build/src/commands/test/index.ts
+++ b/packages/plugins/plugin-build/src/commands/test/index.ts
@@ -48,7 +48,7 @@ export default class Test extends BaseCommand {
       this.context.plugins
     );
 
-    const pluginConfiguration: YarnBuildConfiguration = await GetPluginConfiguration();
+    const pluginConfiguration: YarnBuildConfiguration = await GetPluginConfiguration(configuration);
 
     const report = await StreamReport.start(
       {

--- a/packages/plugins/plugin-build/src/config.ts
+++ b/packages/plugins/plugin-build/src/config.ts
@@ -101,20 +101,19 @@ async function getConfiguration(
       folderConfiguration:
         typeof configOnDisk?.enableBetaFeatures?.folderConfiguration ===
           "string" &&
-        configOnDisk?.enableBetaFeatures?.folderConfiguration === "false"
+          configOnDisk?.enableBetaFeatures?.folderConfiguration === "false"
           ? false
           : true,
       targetedBuilds:
         typeof configOnDisk?.enableBetaFeatures?.targetedBuilds === "string" &&
-        configOnDisk?.enableBetaFeatures?.targetedBuilds === "true"
+          configOnDisk?.enableBetaFeatures?.targetedBuilds === "true"
           ? true
           : false,
     },
   };
 }
 
-async function GetPluginConfiguration(): Promise<YarnBuildConfiguration> {
-  const configuration = await Configuration.find(ppath.cwd(), null);
+async function GetPluginConfiguration(configuration: Configuration): Promise<YarnBuildConfiguration> {
   return await getConfiguration(configuration);
 }
 


### PR DESCRIPTION
Not passing plugins causes parts of previously valid configuration to be detected as invalid. We already have the full configuration at hand, so we can just use that one.

Fixes #37


