### PR TITLE
fix: Unable to build workspaces with circular dependencies

### DIFF
--- a/packages/plugins/plugin-build/src/commands/supervisor/graph.ts
+++ b/packages/plugins/plugin-build/src/commands/supervisor/graph.ts
@@ -76,7 +76,7 @@ class Graph {
       this.resolveQueue(n, queue, runLog);
     }
 
-    await new Promise((resolve) => {
+    await new Promise<void>((resolve) => {
       this.workLoop(queue, runLog, progress, resolve);
     });
 
@@ -168,8 +168,6 @@ class Graph {
       .every((v) => v === true);
   };
 }
-
-type RunThread = Promise<void>;
 
 type RunQueueItem = {
   node: Node;


### PR DESCRIPTION
A simple `Map` to keep track of already planned workspaces. I'm not too sure with the approach, but it seems to work as expected.

It actually works better than expected, because now a lot more projects seem to be built at the same time. Which makes me think something is actually not right. Or this is actually the correct result when having circular dependencies, as the order isn't clear.

This also includes some random cleanups and fixes already present in other PRs. I can rebase later if needed.

Fixes #64 