### PR TITLE
Fix documentation

### DIFF
--- a/packages/plugins/plugin-build/src/commands/bundle/index.ts
+++ b/packages/plugins/plugin-build/src/commands/bundle/index.ts
@@ -60,7 +60,7 @@ export default class Bundler extends BaseCommand {
       \`-o,--output-directory\` sets the output directory.
 
       \`-a,--archive-name\` sets the name of the archive. Any files matching
-      this, will be excluded from subsequent archives. Defaults to ./bundle.tgz
+      this, will be excluded from subsequent archives. Defaults to ./bundle.zip
     `,
   });
 


### PR DESCRIPTION
While having a look at the sources, I think I have found is an inconsistency between the sources and the CLI help string. It certainly happened after https://github.com/ojkelly/yarn.build/pull/61. Hope it is valid 😄 Feel free to close otherwise.

https://github.com/ojkelly/yarn.build/blob/b0f35c7a5d47091a20ddb26dea805e591a0009e0/packages/plugins/plugin-build/src/commands/bundle/index.ts#L31-L64