### PR TITLE
fix: correctly join portable paths when bundling

### DIFF
--- a/packages/plugins/plugin-build/src/commands/bundle/index.ts
+++ b/packages/plugins/plugin-build/src/commands/bundle/index.ts
@@ -144,7 +144,7 @@ export default class Bundler extends BaseCommand {
 
     for (const file of files) {
       await this.removeEmptyDirectories({
-        cwd: path.join(cwd, file) as PortablePath,
+        cwd: ppath.join(cwd, file),
       });
     }
     files = await xfs.readdirPromise(cwd);


### PR DESCRIPTION
On Windows, when traversing directories to delete empty directories, the bundle command incorrectly joined paths with `path.join` when `ppath.join` should have been used. As a result, the `removeEmptyDirectories` recursed into invalid paths and the check for whether the invalid path is a directory failed due to `ENOENT: no such file or directory`.

Fixes #119