### PR TITLE
Use `xfs` instead of `fs` when using portable paths

### DIFF
--- a/packages/plugins/plugin-build/src/commands/bundle/index.ts
+++ b/packages/plugins/plugin-build/src/commands/bundle/index.ts
@@ -1,5 +1,4 @@
 import { BaseCommand, WorkspaceRequiredError } from "@yarnpkg/cli";
-import fs from "fs";
 import {
   Cache,
   Configuration,
@@ -225,7 +224,7 @@ export default class Bundler extends BaseCommand {
       if (typeof this.outputDirectory == "string") {
         const resolvedOutputDir = resolveNativePath(this.outputDirectory);
 
-        if (!fs.existsSync(resolvedOutputDir)) {
+        if (!xfs.existsSync(resolvedOutputDir)) {
           // console.error("ERROR: --output-directory does not exist");
 
           // return 1;


### PR DESCRIPTION
Fix that @merceyz found 

https://github.com/ojkelly/yarn.build/pull/126#discussion_r734957117