### PR TITLE
CI improvements, print progress, and `--changes` fixes  #159 #150

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -1508,6 +1508,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@ojkelly/yarn-plugin-test", "workspace:packages/plugins/plugin-test"],
             ["@ojkelly/yarn-build-shared", "workspace:packages/plugins/shared"],
+            ["@ojkelly/yarn-plugin-build", "workspace:packages/plugins/plugin-build"],
             ["@types/is-ci", "npm:2.0.0"],
             ["@types/jest", "npm:26.0.24"],
             ["@types/js-yaml", "npm:4.0.2"],

--- a/packages/plugins/plugin-build/src/commands/build/index.ts
+++ b/packages/plugins/plugin-build/src/commands/build/index.ts
@@ -62,6 +62,14 @@ export default class Build extends BaseCommand {
     description: `exit immediately upon build failing`,
   });
 
+  onlyGitChanges = Option.Boolean("--changes", false, {
+    description: `only build packages that were changed in the last commit`,
+  });
+
+  onlyGitChangesSinceCommit = Option.String("--since", {
+    description: `only build packages that were changed since the given commit`,
+  });
+
   public buildTargets = Option.Rest({ name: "workspaceNames" });
 
   static usage: Usage = Command.Usage({

--- a/packages/plugins/plugin-test/package.json
+++ b/packages/plugins/plugin-test/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@ojkelly/yarn-build-shared": "workspace:*",
+    "@ojkelly/yarn-plugin-build": "workspace:*",
     "@types/slice-ansi": "^4.0.0",
     "@yarnpkg/fslib": "*",
     "@yarnpkg/libzip": "*",

--- a/packages/plugins/plugin-test/src/commands/test/index.ts
+++ b/packages/plugins/plugin-test/src/commands/test/index.ts
@@ -46,6 +46,14 @@ export default class Test extends BaseCommand {
     description: `exit immediately upon build failing`,
   });
 
+  onlyGitChanges = Option.Boolean("--changes", false, {
+    description: `only build packages that were changed in the last commit`,
+  });
+
+  onlyGitChangesSinceCommit = Option.String("--since", {
+    description: `only build packages that were changed since the given commit`,
+  });
+
   public runTarget: string[] = Option.Rest();
 
   static usage: Usage = Command.Usage({

--- a/packages/plugins/plugin-test/src/commands/test/index.ts
+++ b/packages/plugins/plugin-test/src/commands/test/index.ts
@@ -1,203 +1,21 @@
-import { BaseCommand } from "@yarnpkg/cli";
-import {
-  Configuration,
-  MessageName,
-  Project,
-  StreamReport,
-  miscUtils,
-} from "@yarnpkg/core";
-import { PortablePath } from "@yarnpkg/fslib";
 import { Command, Option, Usage } from "clipanion";
-import path from "path";
 
-import { EventEmitter } from "events";
-import {
-  GetPluginConfiguration,
-  YarnBuildConfiguration,
-} from "@ojkelly/yarn-build-shared/src/config";
-import RunSupervisor, {
-  RunSupervisorReporterEvents,
-} from "@ojkelly/yarn-build-shared/src/supervisor";
+import Build from "@ojkelly/yarn-plugin-build/src/commands/build";
 
-import { addTargets } from "@ojkelly/yarn-build-shared/src/supervisor/workspace";
-import { terminateProcess } from "@ojkelly/yarn-build-shared/src/supervisor/terminate";
-
-export default class Test extends BaseCommand {
+export default class Test extends Build {
   static paths = [[`test`]];
-
-  json = Option.Boolean(`--json`, false, {
-    description: `flag is set the output will follow a JSON-stream output
-      also known as NDJSON (https://github.com/ndjson/ndjson-spec).`,
-  });
-
-  verbose = Option.Boolean(`-v,--verbose`, false, {
-    description: `more information will be logged to stdout than normal.`,
-  });
-
-  ignoreTestCache = Option.Boolean(`-r,--ignore-cache`, false, {
-    description: `every package will be tested, regardless of whether is has changed or not.`,
-  });
-
-  maxConcurrency = Option.String(`-m,--max-concurrency`, {
-    description: `is the maximum number of tests that can run at a time, defaults to the number of logical CPUs on the current machine. Will override the global config option.`,
-  });
-
-  shouldBailInstantly = Option.Boolean("--bail", false, {
-    description: `exit immediately upon build failing`,
-  });
-
-  onlyGitChanges = Option.Boolean("--changes", false, {
-    description: `only build packages that were changed in the last commit`,
-  });
-
-  onlyGitChangesSinceCommit = Option.String("--since", {
-    description: `only build packages that were changed since the given commit`,
-  });
-
-  public runTarget: string[] = Option.Rest();
 
   static usage: Usage = Command.Usage({
     category: `Test commands`,
     description: `test a package and all its dependencies`,
     details: `
-    In a monorepo with internal packages that depend on others, this command
-    will traverse the dependency graph and efficiently ensure, the packages
-    are tested in the right order.
-    `,
+      In a monorepo with internal packages that depend on others, this command
+      will traverse the dependency graph and efficiently ensure, the packages
+      are tested in the right order.
+      `,
   });
 
-  forceQuit = false;
-
-  // Keep track of what is built, and if it needs to be rebuilt
-  runLog: { [key: string]: { hash: string | undefined } } = {};
-
-  async execute(): Promise<0 | 1> {
-    const configuration = await Configuration.find(
-      this.context.cwd,
-      this.context.plugins
-    );
-
-    const pluginConfiguration: YarnBuildConfiguration =
-      await GetPluginConfiguration(configuration);
-
-    this.shouldBailInstantly =
-      this.shouldBailInstantly ?? pluginConfiguration.bail;
-
-    // Safe to run because the input string is validated by clipanion using the schema property
-    // TODO: Why doesn't the Command validation cast this for us?
-    const maxConcurrency =
-      this.maxConcurrency === undefined
-        ? pluginConfiguration.maxConcurrency
-        : parseInt(this.maxConcurrency);
-
-    const report = await StreamReport.start(
-      {
-        configuration,
-        json: this.json,
-        stdout: this.context.stdout,
-        includeLogs: true,
-      },
-      async (report: StreamReport) => {
-        let targetDirectory = this.context.cwd;
-
-        if (typeof this.runTarget[0] === "string") {
-          targetDirectory =
-            `${configuration.projectCwd}${path.posix.sep}${this.runTarget[0]}` as PortablePath;
-        }
-
-        const { project, workspace: cwdWorkspace } = await Project.find(
-          configuration,
-          targetDirectory
-        );
-
-        const targetWorkspace = cwdWorkspace || project.topLevelWorkspace;
-
-        const runScript = async (
-          command: string,
-          cwd: PortablePath,
-          runReporter: EventEmitter,
-          prefix: string
-        ) => {
-          const stdout = new miscUtils.BufferStream();
-
-          stdout.on("data", (chunk) =>
-            runReporter?.emit(
-              RunSupervisorReporterEvents.info,
-              prefix,
-              chunk && chunk.toString()
-            )
-          );
-
-          const stderr = new miscUtils.BufferStream();
-
-          stderr.on("data", (chunk) =>
-            runReporter?.emit(
-              RunSupervisorReporterEvents.error,
-              prefix,
-              chunk && chunk.toString()
-            )
-          );
-          if (this.forceQuit) {
-            stdout.destroy();
-            stderr.destroy();
-            stdout.end();
-            stderr.end();
-
-            return 2;
-          }
-          try {
-            const exitCode =
-              (await this.cli.run(["run", command], {
-                cwd,
-                stdout,
-                stderr,
-              })) || 0;
-
-            stdout.end();
-            stderr.end();
-
-            return exitCode;
-          } catch (err) {
-            stdout.end();
-            stderr.end();
-          }
-
-          return 2;
-        };
-
-        const supervisor = new RunSupervisor({
-          project,
-          configuration,
-          pluginConfiguration,
-          report,
-          runCommand: "test",
-          cli: runScript,
-          dryRun: false,
-          ignoreRunCache: this.ignoreTestCache,
-          verbose: this.verbose,
-          concurrency: maxConcurrency,
-          shouldBailInstantly: this.shouldBailInstantly,
-        });
-
-        supervisor.runReporter.on(RunSupervisorReporterEvents.forceQuit, () => {
-          this.forceQuit = true;
-        });
-
-        await supervisor.setup();
-
-        await addTargets({ targetWorkspace, project, supervisor });
-
-        // test all the things
-        const ranWithoutErrors = await supervisor.run();
-
-        if (ranWithoutErrors === false) {
-          report.reportError(MessageName.BUILD_FAILED, "Test failed");
-        }
-      }
-    );
-
-    terminateProcess.hasBeenTerminated = true;
-
-    return report.exitCode();
-  }
+  buildCommand = Option.String(`-c,--command`, `test`, {
+    description: `the command to be run in each package (if available), defaults to "test"`,
+  });
 }

--- a/packages/plugins/shared/src/changes.ts
+++ b/packages/plugins/shared/src/changes.ts
@@ -1,0 +1,44 @@
+import { exec } from "child_process";
+import { Workspace } from "@yarnpkg/core";
+import { PortablePath } from "@yarnpkg/fslib";
+
+async function GetChangedWorkspaces(
+  root: Workspace,
+  commit: string
+): Promise<Workspace[]> {
+  return new Promise((resolve, reject) => {
+    exec(`git diff --name-only HEAD~${commit}`, (error, stdout, stderr) => {
+      if (error) {
+        reject(error);
+      }
+
+      if (stdout) {
+        const files = stdout.split("\n");
+        const matched = [...root.workspacesCwds]
+          .map((workspacePath) => {
+            if (
+              files.some((v) =>
+                v.startsWith(workspacePath.replace(`${root.cwd}/`, ""))
+              )
+            ) {
+              return workspacePath;
+            }
+
+            return undefined;
+          })
+          .filter((item): item is PortablePath => !!item);
+
+        const r = matched
+          .map((p) => !!p && root.project.workspacesByCwd.get(p))
+          .filter((item): item is Workspace => !!item);
+
+        resolve(r);
+      }
+      if (stderr) {
+        resolve([]);
+      }
+    });
+  });
+}
+
+export { GetChangedWorkspaces };

--- a/packages/plugins/shared/src/supervisor/index.ts
+++ b/packages/plugins/shared/src/supervisor/index.ts
@@ -610,15 +610,17 @@ class RunSupervisor {
 
     this.runReport.runStart = Date.now();
 
-    // Print our RunReporter output
-    if (!this.dryRun && !isCI) {
-      Hansi.pad(this.concurrency + 3); // ensure we have the space we need (required if we start near the bottom of the display).
-      this.raf(this.waitUntilDone);
-    }
-
     if (this.dryRun) {
       return true;
     }
+
+    // Print our RunReporter output
+    if (!isCI) {
+      Hansi.pad(this.concurrency + 3); // ensure we have the space we need (required if we start near the bottom of the display).
+    }
+
+    // print progress
+    this.raf(this.waitUntilDone);
 
     this.currentRunTarget =
       this.runTargets.length > 1
@@ -778,12 +780,25 @@ class RunSupervisor {
     if (this.runReport.done) {
       return;
     }
-    const output = this.generateProgressString(timestamp);
 
-    Hansi.cursorUp(
-      Hansi.linesRequired(this.runReport.previousOutput, process.stdout.columns)
-    );
-    Hansi.clearScreenDown();
+    let waitTime = 90;
+    let output = "";
+
+    if (isCI) {
+      waitTime = 2000;
+
+      output = this.generateProgressStringIsCI(timestamp);
+    } else {
+      output = this.generateProgressString(timestamp);
+
+      Hansi.cursorUp(
+        Hansi.linesRequired(
+          this.runReport.previousOutput,
+          process.stdout.columns
+        )
+      );
+      Hansi.clearScreenDown();
+    }
 
     if (typeof output != `undefined` && typeof output === `string`) {
       process.stdout.write(output);
@@ -791,7 +806,7 @@ class RunSupervisor {
 
     this.runReport.previousOutput = output;
 
-    delay(90).then(() => {
+    delay(waitTime).then(() => {
       this.raf(this.waitUntilDone);
     });
   };
@@ -822,6 +837,35 @@ class RunSupervisor {
         ? formatUtils.pretty(this.configuration, ` --dry-run`, FormatType.NAME)
         : ""
     }`;
+  }
+
+  generateProgressStringIsCI(timestamp: number): string {
+    let output = "";
+
+    if (this.runReport.runStart) {
+      const successString = formatUtils.pretty(
+        this.configuration,
+        `${this.runReport.successCount}`,
+        "green"
+      );
+      const failedString = formatUtils.pretty(
+        this.configuration,
+        `${this.runReport.failCount}`,
+        "red"
+      );
+      const totalString = formatUtils.pretty(
+        this.configuration,
+        `${this.runGraph.runSize}`,
+        "white"
+      );
+
+      output += `-[Success: ${successString}\tFailed: ${failedString}\tTotal:  ${totalString}\tRuntime: ${formatTimestampDifference(
+        this.runReport.runStart,
+        timestamp
+      )}\t]-\n`;
+    }
+
+    return output;
   }
 
   generateProgressString(timestamp: number): string {

--- a/packages/plugins/shared/src/supervisor/index.ts
+++ b/packages/plugins/shared/src/supervisor/index.ts
@@ -859,7 +859,7 @@ class RunSupervisor {
         "white"
       );
 
-      output += `-[Success: ${successString}\tFailed: ${failedString}\tTotal:  ${totalString}\tRuntime: ${formatTimestampDifference(
+      output += `-[  Success: ${successString}\tFailed: ${failedString}\tTotal:  ${totalString}\tRuntime: ${formatTimestampDifference(
         this.runReport.runStart,
         timestamp
       )}\t]-\n`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1115,6 +1115,7 @@ __metadata:
   resolution: "@ojkelly/yarn-plugin-test@workspace:packages/plugins/plugin-test"
   dependencies:
     "@ojkelly/yarn-build-shared": "workspace:*"
+    "@ojkelly/yarn-plugin-build": "workspace:*"
     "@types/is-ci": ^2.0.0
     "@types/jest": ^26.0.19
     "@types/js-yaml": ^4.0.2


### PR DESCRIPTION
Adds `--changed` to only build or test workspaces with files changed according to git.
Adds `--since {commithash|numCommitsToLookBack}` to build the last 5 commits of changes `--since 5` or a specific hash `--since hash`

Adds progress printer when in CI.