### PR TITLE
fix: circular dependency hack

### DIFF
--- a/packages/plugins/shared/src/supervisor/index.ts
+++ b/packages/plugins/shared/src/supervisor/index.ts
@@ -573,7 +573,13 @@ class RunSupervisor {
     return this.pluginConfiguration;
   }
 
+  hasRun: string[] = [];
+
   private async checkIfRunIsRequired(workspace: Workspace): Promise<boolean> {
+    if (workspace.relativeCwd && this.hasRun.includes(workspace.relativeCwd)) {
+      return false;
+    }
+    this.hasRun.push(workspace.relativeCwd);
     if (this.ignoreRunCache === true) {
       return true;
     }

--- a/packages/plugins/shared/src/supervisor/index.ts
+++ b/packages/plugins/shared/src/supervisor/index.ts
@@ -481,9 +481,11 @@ class RunSupervisor {
           continue;
         }
 
-        const parentHasDependency = !!parent.dependencies.find((item) => item?.workspace?.manifest.name?.name === descriptor.name);
+        const parentHasDependency = !!parent.dependencies.find(
+          (item) => item?.workspace?.manifest.name?.name === descriptor.name
+        );
 
-        if  (parentHasDependency) {
+        if (parentHasDependency) {
           continue;
         }
 

--- a/packages/plugins/shared/src/supervisor/index.ts
+++ b/packages/plugins/shared/src/supervisor/index.ts
@@ -481,6 +481,12 @@ class RunSupervisor {
           continue;
         }
 
+        const parentHasDependency = !!parent.dependencies.find((item) => item?.workspace?.manifest.name?.name === descriptor.name);
+
+        if  (parentHasDependency) {
+          continue;
+        }
+
         const dep = this.runGraph
           .addNode(depWorkspace.relativeCwd)
           .addWorkSpace(depWorkspace);


### PR DESCRIPTION
A team using yarn.build had this problem of fighting circular dependencies regularly.

I added this small hack to save them but probably there is a nicer way to do this.