### PR TITLE
Improve `--dry-run`, CI output, and exit code handling

### DIFF
--- a/packages/plugins/plugin-build/src/commands/buildQuery/display/workspace/dependencies/displayDependencies.ts
+++ b/packages/plugins/plugin-build/src/commands/buildQuery/display/workspace/dependencies/displayDependencies.ts
@@ -1,6 +1,9 @@
 import { Project, Workspace } from "@yarnpkg/core";
-import { getInternalDependencies, getName } from "../../../utils";
-import { Maybe } from "../../../../../types";
+import {
+  getInternalDependencies,
+  getName,
+} from "@ojkelly/yarn-plugin-build/src/commands/buildQuery/utils";
+import { Maybe } from "@ojkelly/yarn-build-shared/dist/types";
 import { displayDependency } from "./displayDependency";
 import { DisplayFormatType } from "../..";
 

--- a/packages/plugins/shared/src/supervisor/graph.test.ts
+++ b/packages/plugins/shared/src/supervisor/graph.test.ts
@@ -17,7 +17,7 @@ describe("Simple dependency graph", () => {
     C.addDependency(D);
     C.addDependency(E);
 
-    await graph.resolve(A);
+    await graph.checkCyclical(A);
   });
 
   it("can detect cyclic dependencies", async () => {
@@ -42,7 +42,7 @@ describe("Simple dependency graph", () => {
     expect.assertions(2);
 
     try {
-      graph.resolve(A);
+      graph.checkCyclical(A);
     } catch (err) {
       if (err instanceof CyclicDependencyError) {
         expect(err.node).toMatch("D");


### PR DESCRIPTION
This pr updates the output of `--dry-run`. This adds a print out of the run order.
Each level can be run in parallel to the maximum available concurrency, and subsequent levels cannot start until the previous has finished.

```
[ Run Order ]-------------------------------------------------------------------
├─ packages/examples/words/adipiscing
├─ packages/examples/words/amet
├─ packages/examples/words/consectetur
├─ packages/examples/words/dolor
├─ packages/examples/words/elit
├─ packages/examples/words/ipsum
├─ packages/examples/words/lorem
├─ packages/examples/words/sit
├─ packages/plugins/shared
└─┬ packages/plugins/plugin-package-yaml
  ├─ packages/examples/phrases/in-hac
  ├─ packages/examples/phrases/nullam-risus
  ├─ packages/plugins/plugin-build
  └─┬ packages/plugins/plugin-bundle
    ├─ packages/examples/phrases/lorem-ipsum
    └─┬ packages/plugins/plugin-test
      ├─ packages/examples/lorem-ipsum
      ├─ packages/examples/lorem-ipsum-docker
      └─ packages/plugins/plugin-all
```

This also updates the CI output, to print out when each package has complete. This is based on feedback where the previous output (while it did show progress) was not clear enough about how it works.

```
[ Run / Command: build / Concurrency: 8 ]---------------------------------------
[success] @internal/consectetur                                            6.97s
[success] @internal/sit                                                    7.22s
[success] @internal/ipsum                                                  7.45s
[success] @internal/lorem                                                  7.45s
[success] @internal/amet                                                   7.45s
[success] @internal/dolor                                                  7.45s
[success] @internal/elit                                                   7.45s
[success] @internal/adipiscing                                             7.55s
[success] @internal/phrase-in-hac                                         10.78s
[success] @internal/phrase-nullam-risus                                   10.87s
[success] @ojkelly/yarn-build-shared                                      11.03s
[success] @internal/phrase-lorem-ipsum                                    15.51s
[success] @ojkelly/yarn-plugin-package-yaml                               20.36s
[success] @internal/lorem-ipsum                                           22.12s
[success] @internal/lorem-ipsum-docker                                    22.12s
[success] @ojkelly/yarn-plugin-bundle                                     25.04s
[success] @ojkelly/yarn-plugin-build                                      25.04s
[success] @ojkelly/yarn-plugin-test                                       31.40s
[success] @ojkelly/yarn-plugin-all                                        37.51s

[ build for All ]---------------------------------------------------------------
```

Exit codes above 100 were being treated as force quits, but this was a naive approach that fails in the real world and was suppressing some errors.