### PR TITLE
fix: prevent supervisor hang when a build step fails (#277)

### DIFF
--- a/packages/plugins/shared/src/supervisor/graph.test.ts
+++ b/packages/plugins/shared/src/supervisor/graph.test.ts
@@ -227,7 +227,9 @@ describe("Simple dependency graph", () => {
 
     const runLog = await Promise.race([
       graph.run(context.active(), [A]),
-      new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 2000)),
+      new Promise<"timeout">((resolve) =>
+        setTimeout(() => resolve("timeout"), 2000),
+      ),
     ]);
 
     expect(runLog).not.toBe("timeout");

--- a/packages/plugins/shared/src/supervisor/graph.test.ts
+++ b/packages/plugins/shared/src/supervisor/graph.test.ts
@@ -208,4 +208,33 @@ describe("Simple dependency graph", () => {
 
     expect(runOrder.sort()).toStrictEqual([...new Set(nodes.map((n) => n.id))]);
   });
+
+  it("does not hang when a failing dependency cancels its dependents", async () => {
+    const graph = new Graph();
+
+    const A = graph.addNode("A").addRunCallback(async () => true);
+    const B = graph.addNode("B").addRunCallback(async () => true);
+    const C = graph
+      .addNode("C")
+      .addRunCallback(async (_ctx, cancelDependentJobs: () => void) => {
+        cancelDependentJobs();
+
+        return false;
+      });
+
+    A.addDependency(B);
+    B.addDependency(C);
+
+    const runLog = await Promise.race([
+      graph.run(context.active(), [A]),
+      new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 2000)),
+    ]);
+
+    expect(runLog).not.toBe("timeout");
+    expect(runLog).toMatchObject({
+      A: { done: true, success: false },
+      B: { done: true, success: false },
+      C: { done: true, success: false },
+    });
+  });
 });

--- a/packages/plugins/shared/src/supervisor/graph.ts
+++ b/packages/plugins/shared/src/supervisor/graph.ts
@@ -160,6 +160,14 @@ class Graph {
   ) {
     if (queue.size !== 0) {
       queue.forEach((q) => {
+        if (q?.node?.cancelled) {
+          runLog[q.node.id] = { success: false, done: true };
+          Node.cancelDependentJobs(q.node)();
+          queue.delete(q);
+
+          return;
+        }
+
         if (q.canStart(runLog)) {
           if (q?.node?.runCallback) {
             q?.node?.runCallback(ctx, runLog);
@@ -289,6 +297,8 @@ class Node {
 
     this.runCallback = (ctx: Context, runLog: RunLog) => {
       if (this.cancelled) {
+        runLog[this.id] = { done: true, success: false };
+
         return;
       }
 

--- a/packages/plugins/shared/src/supervisor/index.ts
+++ b/packages/plugins/shared/src/supervisor/index.ts
@@ -1685,6 +1685,10 @@ class RunSupervisor {
                     },
                   );
 
+                  if (this.continueOnError === false) {
+                    cancelDependentJobs();
+                  }
+
                   if (this.failFast === true) {
                     if (isNonInteractive) {
                       process.stdout.write(


### PR DESCRIPTION
Fixes #277 — `yarn build` hangs after compiling all workspaces when a
dependency fails, leaving all threads IDLE.

The root cause is bookkeeping in `RunSupervisor`'s work loop: when a node
is cancelled (because an upstream dependency failed), its `runLog` entry
was never marked `done`, so the loop's completion check (`every done ===
true`) never trips and the 30ms `setTimeout` recursion spins forever.

Three coordinated fixes in `packages/plugins/shared/src/supervisor/`:

- **`graph.ts` — `workLoop`** drains cancelled queue items: marks
  `runLog[id] = {done: true, success: false}` and propagates cancellation
  to that node's dependents via `Node.cancelDependentJobs`, so chains of
  failed dependencies unwind instead of stalling.
- **`graph.ts` — `Node.runCallback`** now writes the run log before
  returning when `cancelled` is true (previously it returned silently,
  leaving the entry stuck at `done: false`).
- **`index.ts`** — the non-zero-exit branch now calls
  `cancelDependentJobs()`, matching the existing behaviour of the
  exception branch. Without this, exit-code failures don't propagate
  cancellation to dependents.

Credit to @alamothe for diagnosing the issue and providing the original
patch against the bundled plugin in #277. This PR ports the fix to source
and extends it to handle transitive cancellation (the patch as-given only
covered single-level cancellation; a 3-node chain still hung without the
propagation extension — verified by the new regression test).