### PR TITLE
fix: correct 'Monorepo's' to 'Monorepos' in docs heading

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -134,7 +134,7 @@
         </header>
 
         <aside>
-          <h3>Built for Monorepo's</h3>
+          <h3>Built for Monorepos</h3>
           <a href="https://yarn.build"
             ><span style="font-family: var(--font-family); font-weight: 100"
               >yarn</span


### PR DESCRIPTION
## Summary

Corrects typo in docs/index.html heading.

**Before:** Built for Monorepo's  
**After:** Built for Monorepos

## Fixes

Fixes issue #279.