### PR TITLE
docs: use monorepos instead of Monorepo's

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -134,7 +134,7 @@
         </header>
 
         <aside>
-          <h3>Built for Monorepo's</h3>
+          <h3>Built for monorepos</h3>
           <a href="https://yarn.build"
             ><span style="font-family: var(--font-family); font-weight: 100"
               >yarn</span


### PR DESCRIPTION
## Summary
Fixes #279 — plural of monorepo should be **monorepos**, not **Monorepo's**.

## Test plan
- [ ] Confirm docs copy reads correctly in `docs/index.html`