### PR TITLE
fix: fix: pluralize monorepos without apostrophe

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -134,7 +134,7 @@
         </header>
 
         <aside>
-          <h3>Built for Monorepo's</h3>
+          <h3>Built for Monorepos</h3>
           <a href="https://yarn.build"
             ><span style="font-family: var(--font-family); font-weight: 100"
               >yarn</span
@@ -147,7 +147,7 @@
               >.BUILD</span
             ></a
           >
-          is designed for monorepo's that use
+          is designed for monorepos that use
           <a href="https://yarnpkg.com/features/workspaces" target="_blank"
             >yarn workspaces</a
           >.


### PR DESCRIPTION
## Summary

fix: pluralize monorepos without apostrophe

## Changes

- docs\index.html

Fixes #279
